### PR TITLE
feat: 미팅 스케줄 스태틱 페이지 구현 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   rules: {
     "spaced-comment": "off",
     "require-jsdoc": "off",
+    "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",
     "no-unused-vars": "off",
   },

--- a/App.js
+++ b/App.js
@@ -1,12 +1,15 @@
 import { StatusBar } from "expo-status-bar";
 import { StyleSheet, View } from "react-native";
 
+import Header from "./component/Header";
 import Login from "./component/Login";
+import MeetingSchedule from "./component/MeetingSchedule";
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Login />
+      <Header />
+      <MeetingSchedule />
       <StatusBar style="auto" />
     </View>
   );
@@ -17,6 +20,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     alignItems: "center",
-    justifyContent: "center",
+    justifyContent: "flex-start",
   },
 });

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
+    plugins: ["react-native-reanimated/plugin"],
   };
 };

--- a/component/Header/index.js
+++ b/component/Header/index.js
@@ -1,0 +1,113 @@
+import React from "react";
+import { StyleSheet, View, Text, TouchableOpacity, Image } from "react-native";
+
+export default function Header() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Meet-Up!</Text>
+        <View style={[styles.profile, { justifyContent: "flex-end" }]}>
+          <View style={styles.profileImgContainer}>
+            <Image
+              source={{
+                uri: "https://lh3.googleusercontent.com/a/AGNmyxa5mqAs837yjRYEkSvflqIJV3vnOFxU3yjyTpd_=s96-c",
+              }}
+              style={styles.profileImg}
+            />
+          </View>
+          <Text style={styles.profileText}>상혁님 안녕하세요</Text>
+        </View>
+      </View>
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity style={styles.button}>
+          <Text style={styles.buttonText}>미팅일정</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button}>
+          <Text style={styles.buttonText}>미팅확인</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button}>
+          <Text style={styles.buttonText}>미팅신청</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button}>
+          <Text style={styles.buttonText}>미팅생성</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 50,
+    marginBottom: 10,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "flex-start",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    width: "100%",
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "#CCC",
+  },
+  headerTitle: {
+    width: "50%",
+    fontWeight: "bold",
+    color: "#FF9900",
+    textShadowColor: "rgba(0, 0, 0, 1)",
+    textShadowOffset: { width: 1, height: 2 },
+    textShadowRadius: 1,
+    fontSize: 30,
+  },
+  profileImgContainer: {
+    width: 35,
+    height: 35,
+    marginRight: 5,
+    borderRadius: 50,
+    overflow: "hidden",
+  },
+  profile: {
+    width: "50%",
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  profileText: {
+    fontWeight: "bold",
+    fontSize: 13,
+  },
+  profileImg: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+  },
+  buttonContainer: {
+    marginTop: 10,
+    alignItems: "center",
+    flexDirection: "row",
+  },
+  button: {
+    backgroundColor: "#FF9900",
+    padding: 10,
+    width: "22%",
+    marginRight: 5,
+    borderRadius: 25,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#000",
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 1,
+      height: 3,
+    },
+    shadowOpacity: 1,
+    shadowRadius: 1,
+  },
+  buttonText: {
+    color: "#FFF",
+    fontSize: 14,
+    fontWeight: "bold",
+  },
+});

--- a/component/Login/index.js
+++ b/component/Login/index.js
@@ -57,7 +57,6 @@ export default function Login() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: "#fff",

--- a/component/MeetingSchedule/index.js
+++ b/component/MeetingSchedule/index.js
@@ -1,0 +1,272 @@
+import React, { useState } from "react";
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native";
+import { PanGestureHandler } from "react-native-gesture-handler";
+import Animated, {
+  useSharedValue,
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+} from "react-native-reanimated";
+
+import ScheduleCard from "../ScheduleCard";
+
+const getDaysInMonth = (month, year) => {
+  return new Date(year, month + 1, 0).getDate();
+};
+
+const getFirstDayInMonth = (month, year) => {
+  return new Date(year, month, 1).getDay();
+};
+
+const CalendarHeader = ({ month, year, onPrev, onNext }) => (
+  <View style={styles.header}>
+    <TouchableOpacity onPress={onPrev}>
+      <Text style={styles.headerButton}>Prev</Text>
+    </TouchableOpacity>
+    <Text style={styles.headerText}>{`${year}.${month + 1}`}</Text>
+    <TouchableOpacity onPress={onNext}>
+      <Text style={styles.headerButton}>Next</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const MonthView = ({ month, year }) => {
+  const daysInMonth = getDaysInMonth(month, year);
+  const firstDayInMonth = getFirstDayInMonth(month, year);
+
+  const [selectedDate, setSelectedDate] = useState(null);
+
+  const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const onDayPress = (day) => {
+    setSelectedDate(day);
+  };
+
+  return (
+    <View style={styles.month}>
+      <View style={styles.weekDaysContainer}>
+        {weekDays.map((day, index) => (
+          <View key={`weekday-${index}`} style={styles.weekDay}>
+            <Text style={styles.weekDayText}>{day}</Text>
+          </View>
+        ))}
+      </View>
+      <View style={styles.daysContainer}>
+        {Array(firstDayInMonth)
+          .fill(null)
+          .map((_, index) => (
+            <View key={`empty-${index}`} style={styles.day} />
+          ))}
+        {Array(daysInMonth)
+          .fill(null)
+          .map((_, index) => {
+            const day = new Date(year, month, index + 1);
+            const isToday = day.getTime() === today.getTime();
+            const isSelected =
+              selectedDate && day.getTime() === selectedDate.getTime();
+
+            const dayStyle = [
+              styles.day,
+              isToday && styles.today,
+              isSelected && styles.selectedDay,
+            ];
+            const dayTextStyle = isToday ? styles.todayText : styles.dayText;
+
+            return (
+              <TouchableOpacity
+                key={`day-${index}`}
+                style={dayStyle}
+                onPress={() => onDayPress(day)}
+              >
+                <Text style={dayTextStyle}>{index + 1}</Text>
+              </TouchableOpacity>
+            );
+          })}
+      </View>
+    </View>
+  );
+};
+
+export default function MeetingSchedule() {
+  const [date, setDate] = useState(new Date());
+  const month = date.getMonth();
+  const year = date.getFullYear();
+
+  const onPrevMonth = () => {
+    runOnJS(setDate)(new Date(year, month - 1, 1));
+  };
+
+  const onNextMonth = () => {
+    runOnJS(setDate)(new Date(year, month + 1, 1));
+  };
+
+  const translateX = useSharedValue(0);
+  const opacity = useSharedValue(1);
+
+  const onGestureEvent = useAnimatedGestureHandler({
+    onActive: (event, ctx) => {
+      translateX.value = event.translationX;
+      opacity.value = 1 - Math.abs(event.translationX / 200);
+    },
+    onEnd: (event, ctx) => {
+      if (event.translationX > 50) {
+        runOnJS(onPrevMonth)();
+      } else if (event.translationX < -50) {
+        runOnJS(onNextMonth)();
+      }
+      translateX.value = withSpring(0);
+      opacity.value = withSpring(1);
+    },
+  });
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateX: translateX.value }],
+      opacity: opacity.value,
+    };
+  });
+
+  return (
+    <ScrollView>
+      <View style={styles.container}>
+        <CalendarHeader
+          month={month}
+          year={year}
+          onPrev={onPrevMonth}
+          onNext={onNextMonth}
+        />
+        <PanGestureHandler onGestureEvent={onGestureEvent}>
+          <Animated.View style={animatedStyle}>
+            <View style={styles.monthWrapper}>
+              <MonthView month={month} year={year} />
+            </View>
+          </Animated.View>
+        </PanGestureHandler>
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+        <ScheduleCard
+          name="이상혁"
+          time="10:00 AM"
+          agenda="어쩌구저쩌구~~"
+          address="어쩌구저쩌구~~"
+        />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "#fff",
+    alignItems: "center",
+    marginTop: 30,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  headerText: {
+    fontSize: 30,
+    fontWeight: "bold",
+  },
+  headerButton: {
+    marginRight: 15,
+    marginLeft: 15,
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  month: {
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  weekDaysContainer: {
+    flexDirection: "row",
+    width: "100%",
+    paddingHorizontal: 10,
+    marginBottom: 5,
+  },
+  weekDay: {
+    width: "14%",
+  },
+  weekDayText: {
+    fontSize: 17,
+    textAlign: "center",
+    fontWeight: "bold",
+  },
+  daysContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    width: "100%",
+    paddingHorizontal: 10,
+  },
+  day: {
+    width: "14%",
+    aspectRatio: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayText: {
+    fontSize: 15,
+    textAlign: "center",
+    fontWeight: "bold",
+  },
+  today: {
+    backgroundColor: "#eee",
+    borderRadius: 50,
+  },
+  todayText: {
+    fontWeight: "bold",
+  },
+  selectedDay: {
+    borderColor: "red",
+    borderWidth: 2,
+    borderRadius: 50,
+  },
+  monthWrapper: {
+    borderWidth: 2,
+    borderColor: "black",
+    borderRadius: 20,
+    padding: 10,
+    width: "90%",
+  },
+});

--- a/component/ScheduleCard/index.js
+++ b/component/ScheduleCard/index.js
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { StyleSheet, Text, View, TouchableOpacity } from "react-native";
+
+const ScheduleCard = ({ name, time, agenda, address }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
+  return (
+    <TouchableOpacity onPress={toggleExpanded} style={styles.card}>
+      <Text style={styles.cardTitle}>{name}</Text>
+      <Text style={styles.cardTime}>{time}</Text>
+      {expanded && (
+        <View style={styles.cardDetails}>
+          <Text style={styles.cardAgenda}>미팅안건: {agenda}</Text>
+          <Text style={styles.cardAddress}>미팅주소: {address}</Text>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#f8f8f8",
+    borderRadius: 10,
+    marginTop: 10,
+    padding: 15,
+    marginBottom: 10,
+    width: "100%",
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  cardTime: {
+    fontSize: 16,
+    marginTop: 5,
+  },
+  cardDetails: {
+    marginTop: 10,
+  },
+  cardAgenda: {
+    fontSize: 14,
+    marginBottom: 5,
+  },
+  cardAddress: {
+    fontSize: 14,
+  },
+});
+
+export default ScheduleCard;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "meetup-client",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-community/datetimepicker": "6.7.3",
         "expo": "~48.0.10",
+        "expo-location": "~15.1.1",
         "expo-status-bar": "~1.4.4",
         "react": "18.2.0",
-        "react-native": "0.71.6"
+        "react-native": "0.71.6",
+        "react-native-gesture-handler": "^2.9.0",
+        "react-native-reanimated": "2.14.4",
+        "react-navigation": "^4.4.4"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -1310,6 +1315,20 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-object-assign": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz",
+      "integrity": "sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -1793,6 +1812,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4793,6 +4823,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-6.7.3.tgz",
+      "integrity": "sha512-fXWbEdHMLW/e8cts3snEsbOTbnFXfUHeO2pkiDFX3fWpFoDtUrRWvn50xbY13IJUUKHDhoJ+mj24nMRVIXfX1A==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      }
+    },
     "node_modules/@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",
@@ -4807,6 +4845,34 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
+    },
+    "node_modules/@react-navigation/core": {
+      "version": "3.7.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.7.9.tgz",
+      "integrity": "sha512-EknbzM8OI9A5alRxXtQRV5Awle68B+z1QAxNty5DxmlS3BNfmduWNGnim159ROyqxkuDffK9L/U/Tbd45mx+Jg==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2",
+        "path-to-regexp": "^1.8.0",
+        "query-string": "^6.13.6",
+        "react-is": "^16.13.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.8.4.tgz",
+      "integrity": "sha512-gXSVcL7bfFDyVkvyg1FiAqTCIgZub5K1X/TZqURBs2CPqDpfX1OsCtB9D33eTF14SpbfgHW866btqrrxoCACfg==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2",
+        "react-native-safe-area-view": "^0.14.9"
+      }
     },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
@@ -4855,6 +4921,11 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -8187,6 +8258,14 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-location": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-15.1.1.tgz",
+      "integrity": "sha512-hoKRlmi6Ya+NeZ72Zt385SDcSsIDpJI60TCBVO+Hc9xfKA9Hyminyyo5WiwI8J03igmPTCl8Y37MxBNKY9AWkg==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.1.2.tgz",
@@ -8496,6 +8575,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -9137,6 +9224,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -11206,6 +11306,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13166,6 +13271,19 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -13556,6 +13674,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -13722,10 +13857,62 @@
         "nullthrows": "^1.1.1"
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
+      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-gradle-plugin": {
       "version": "0.71.17",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
       "integrity": "sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA=="
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
+      "integrity": "sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==",
+      "dependencies": {
+        "@babel/plugin-transform-object-assign": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^1.7.0",
+        "invariant": "^2.2.4",
+        "lodash.isequal": "^4.5.0",
+        "setimmediate": "^1.0.5",
+        "string-hash-64": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-view": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.14.9.tgz",
+      "integrity": "sha512-WII/ulhpVyL/qbYb7vydq7dJAfZRBcEhg4/UWt6F6nAKpLa3gAceMOxBxI914ppwSP/TdUsandFy6lkJQE0z4A==",
+      "dependencies": {
+        "hoist-non-react-statics": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-view/node_modules/hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "node_modules/react-native/node_modules/promise": {
       "version": "8.3.0",
@@ -13733,6 +13920,20 @@
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/react-navigation": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-4.4.4.tgz",
+      "integrity": "sha512-08Nzy1aKEd73496CsuzN49vLFmxPKYF5WpKGgGvkQ10clB79IRM2BtAfVl6NgPKuUM8FXq1wCsrjo/c5ftl5og==",
+      "deprecated": "This package is no longer supported. Please use @react-navigation/native instead. See https://reactnavigation.org/docs/getting-started/ for usage guide",
+      "dependencies": {
+        "@react-navigation/core": "^3.7.9",
+        "@react-navigation/native": "^3.8.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-refresh": {
@@ -14622,6 +14823,14 @@
         "node": "*"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14796,6 +15005,14 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -14812,6 +15029,11 @@
       "engines": {
         "node": ">=0.6.19"
       }
+    },
+    "node_modules/string-hash-64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
+      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -17024,6 +17246,14 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz",
+      "integrity": "sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -17360,6 +17590,14 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
       }
     },
     "@eslint-community/eslint-utils": {
@@ -19631,6 +19869,14 @@
         "joi": "^17.2.1"
       }
     },
+    "@react-native-community/datetimepicker": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-6.7.3.tgz",
+      "integrity": "sha512-fXWbEdHMLW/e8cts3snEsbOTbnFXfUHeO2pkiDFX3fWpFoDtUrRWvn50xbY13IJUUKHDhoJ+mj24nMRVIXfX1A==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",
@@ -19645,6 +19891,33 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
+    },
+    "@react-navigation/core": {
+      "version": "3.7.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.7.9.tgz",
+      "integrity": "sha512-EknbzM8OI9A5alRxXtQRV5Awle68B+z1QAxNty5DxmlS3BNfmduWNGnim159ROyqxkuDffK9L/U/Tbd45mx+Jg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2",
+        "path-to-regexp": "^1.8.0",
+        "query-string": "^6.13.6",
+        "react-is": "^16.13.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "@react-navigation/native": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.8.4.tgz",
+      "integrity": "sha512-gXSVcL7bfFDyVkvyg1FiAqTCIgZub5K1X/TZqURBs2CPqDpfX1OsCtB9D33eTF14SpbfgHW866btqrrxoCACfg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2",
+        "react-native-safe-area-view": "^0.14.9"
+      }
     },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
@@ -19693,6 +19966,11 @@
       "requires": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "@types/hammerjs": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -22160,6 +22438,12 @@
       "integrity": "sha512-hqeCnb4033TyuZaXs93zTK7rjVJ3bywXATyMmKmKkLEsH2PKBAl/VmjlCOPQL/2Ncqz6aj7Wo//tjeJTARBD4g==",
       "requires": {}
     },
+    "expo-location": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-15.1.1.tgz",
+      "integrity": "sha512-hoKRlmi6Ya+NeZ72Zt385SDcSsIDpJI60TCBVO+Hc9xfKA9Hyminyyo5WiwI8J03igmPTCl8Y37MxBNKY9AWkg==",
+      "requires": {}
+    },
     "expo-modules-autolinking": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.1.2.tgz",
@@ -22411,6 +22695,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -22878,6 +23167,21 @@
       "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
       "requires": {
         "source-map": "^0.7.3"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "hosted-git-info": {
@@ -24377,6 +24681,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -25888,6 +26197,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -26168,6 +26492,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -26297,10 +26632,60 @@
         "nullthrows": "^1.1.1"
       }
     },
+    "react-native-gesture-handler": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
+      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
+      "requires": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-gradle-plugin": {
       "version": "0.71.17",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
       "integrity": "sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA=="
+    },
+    "react-native-reanimated": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
+      "integrity": "sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==",
+      "requires": {
+        "@babel/plugin-transform-object-assign": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^1.7.0",
+        "invariant": "^2.2.4",
+        "lodash.isequal": "^4.5.0",
+        "setimmediate": "^1.0.5",
+        "string-hash-64": "^1.0.3"
+      }
+    },
+    "react-native-safe-area-view": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.14.9.tgz",
+      "integrity": "sha512-WII/ulhpVyL/qbYb7vydq7dJAfZRBcEhg4/UWt6F6nAKpLa3gAceMOxBxI914ppwSP/TdUsandFy6lkJQE0z4A==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-navigation": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-4.4.4.tgz",
+      "integrity": "sha512-08Nzy1aKEd73496CsuzN49vLFmxPKYF5WpKGgGvkQ10clB79IRM2BtAfVl6NgPKuUM8FXq1wCsrjo/c5ftl5og==",
+      "requires": {
+        "@react-navigation/core": "^3.7.9",
+        "@react-navigation/native": "^3.8.4"
+      }
     },
     "react-refresh": {
       "version": "0.4.3",
@@ -27005,6 +27390,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -27141,6 +27531,11 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="
     },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -27154,6 +27549,11 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
+    },
+    "string-hash-64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
+      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,15 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "6.7.3",
     "expo": "~48.0.10",
+    "expo-location": "~15.1.1",
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
-    "react-native": "0.71.6"
+    "react-native": "0.71.6",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "2.14.4",
+    "react-navigation": "^4.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## 📝 Description
미팅 스케줄 페이지에 필요한 컴퍼넌트를 만들어 주었습니다.
`<Header>` 앱 이름과 사용자 이름, 카테고리를  헤더 컴퍼넌트를 만들어 주었습니다.
`<ScheduleCard>` 시간, 스케줄 신청이름, 주소, 미팅 안건, 을 표시해주는 컴퍼넌트를 만들어 주었습니다. 
`<MeetingSchedule>` 캘린더를 만들어 주었고 해당날짜 클릭, 현재 날짜 표시 한달단위로 이동(슬라이드 가능) 을 구현해주었습니다.

## ❗ Related Issues
캘린더기능을 로컬기반 시간과 현재 있는 지역 위치시간 중 현재 있는 위치로 캘린더를 만들게 된다면 `API`의 의존도가 많이 높아져 로컬기반 캘리더로 만들어 주었습니다.

## 🛠️ Changes
N/A

## 📸 Screenshot
<img width="400" alt="image" src="https://user-images.githubusercontent.com/107290583/230717918-855076eb-5916-4061-ad36-0e55831564ba.png">

